### PR TITLE
Refactor Engine Strategies & Add Prolog Engine Strategy

### DIFF
--- a/agent/logic/agent.py
+++ b/agent/logic/agent.py
@@ -67,9 +67,6 @@ class LogicAgent(Solver):
             engine_strategy (EngineStrategy): Agent configuration (e.g. CBMC
             search or SMT conclusion check).
             result_trace (ResultTrace): Sink for debug and result output data.
-            collect_pyre_type_information (bool): Whether libCST modules should
-            be parsed with type information. This incurs a performance overhead,
-            but is necessary for the Z3 back-end.
         """
         self.__logger: Logger = logger_factory(__name__)
         self.__engine_strategy: EngineStrategy = engine_strategy
@@ -247,10 +244,9 @@ Constraints:
             self.__result_trace.solver_exit_code = solver_exit_code
             if not stdout:
                 return None, True
-            solverSpec.content = stdout
 
             solver_outcome, output = self.__engine_strategy.parse_solver_output(
-                solver_exit_code, solverSpec, stderr
+                solver_exit_code, solverSpec, stdout, stderr
             )
             match solver_outcome:
                 case SolverOutcome.SUCCESS:

--- a/agent/logic/agent.py
+++ b/agent/logic/agent.py
@@ -10,17 +10,14 @@ from re import compile, DOTALL, Match, Pattern
 from tempfile import gettempdir
 from typing import Callable, Optional, Tuple
 
-from agent.logic.engine_strategy import EngineStrategy, SolverOutcome
+from agent.logic.engine_strategy import EngineStrategy, SolverOutcome, SolverConstraints
 from agent.logic.solver import Solver
-from agent.symex.module_with_type_info_factory import ModuleWithTypeInfoFactory
 from aiofiles.tempfile import NamedTemporaryFile
 from concurrency.subprocess import Subprocess
 from inference.chat_completion import ChatCompletion, Role
 from inference.client import InferenceClient
 
 from judge.result_trace import ResultTrace
-
-from libcst import MetadataWrapper, Module, parse_module, ParserSyntaxError
 
 
 # Sent if an expected code snippet was not found.
@@ -58,7 +55,6 @@ class LogicAgent(Solver):
         chat_completion: ChatCompletion,
         engine_strategy: EngineStrategy,
         result_trace: ResultTrace,
-        collect_pyre_type_information: bool = False,
     ) -> None:
         """
         Initialises inference client with default settings and the provided
@@ -79,7 +75,6 @@ class LogicAgent(Solver):
         self.__engine_strategy: EngineStrategy = engine_strategy
         self.__client = InferenceClient(logger_factory, chat_completion)
         self.__result_trace: ResultTrace = result_trace
-        self.__collect_pyre_type_information: bool = collect_pyre_type_information
 
     async def solve(self) -> None:
         """
@@ -127,6 +122,7 @@ Constraints:
         spreading Python code across mutltiple messages.
         """
         data_structure: Optional[str] = await self.__generate_data_structure()
+
         if not data_structure:
             return False
 
@@ -189,34 +185,29 @@ Constraints:
                     return None, False
                 all_constraints.append(constraints)
 
-            python_code: str = f"""
+            code: str = f"""
 {self.__engine_strategy.python_code_prefix}
 {data_structure}
 {os.linesep.join(all_constraints)}
 """
-            self.__result_trace.python_code = python_code
+            self.__result_trace.python_code = code
 
-            module: Module
-            metadata: Optional[MetadataWrapper]
             try:
-                if self.__collect_pyre_type_information:
-                    metadata = await ModuleWithTypeInfoFactory.create_module(
-                        python_code
-                    )
-                    module = metadata.module
-                else:
-                    module = parse_module(python_code)
-                    metadata = None
-            except ParserSyntaxError:
-                self.__logger.exception("Parser error when reading constraint")
+                solverSpec: Optional[SolverConstraints] = (
+                await self.__engine_strategy.generate_solver_constraints(
+                   code
+                )
+            )
+
+            except Exception as e:
+                self.__logger.exception(f"Parser error when reading constraint: {e}")
                 self.__result_trace.num_logic_py_syntax_errors += 1
                 return None, True
 
-            solver_constraints: str = (
-                await self.__engine_strategy.generate_solver_constraints(
-                    module, metadata
-                )
-            )
+            if not solverSpec:
+                return None, False
+
+            solver_constraints = solverSpec.content
             self.__result_trace.solver_constraints = solver_constraints
 
             solver_input_file_suffix: str = (
@@ -226,7 +217,7 @@ Constraints:
             stdout: str
             stderr: str
             async with NamedTemporaryFile(
-                mode="w", suffix=solver_input_file_suffix, delete_on_close=False
+                mode="w", suffix=solver_input_file_suffix, delete=False
             ) as file:
                 await file.write(solver_constraints)
                 await file.close()
@@ -254,9 +245,12 @@ Constraints:
 
             self.__result_trace.solver_output = f"{stdout}{stderr}"
             self.__result_trace.solver_exit_code = solver_exit_code
+            if not stdout:
+                return None, True
+            solverSpec.content = stdout
 
             solver_outcome, output = self.__engine_strategy.parse_solver_output(
-                solver_exit_code, stdout, stderr
+                solver_exit_code, solverSpec, stderr
             )
             match solver_outcome:
                 case SolverOutcome.SUCCESS:

--- a/agent/logic/cbmc_search_engine_strategy.py
+++ b/agent/logic/cbmc_search_engine_strategy.py
@@ -9,9 +9,9 @@ from json import loads
 from logging import Logger
 from typing import Any, Callable, Optional, Tuple
 
-from agent.logic.engine_strategy import EngineStrategy, SolverOutcome
+from agent.logic.engine_strategy import EngineStrategy, SolverOutcome, SolverConstraints
 from agent.logic.logic_py_c_harness_generator import LogicPyCHarnessGenerator
-from libcst import MetadataWrapper, Module
+from libcst import MetadataWrapper, Module, parse_module
 
 
 # Instructs the model to generate the solution constraints.
@@ -80,7 +80,7 @@ I will walk you through these steps one by one. Do not attempt to solve the puzz
 Your solver tool allows you to specify the output solution type as Python classes, with a few additional features:
 
 * Just like in SQL, each field can be marked as unique, meaning no two instances of the class can have the same value, e.g.: `id: Unique[int]`
-* Each field can have a value constraint assigned to it, such that only these values are allowed, e.g.: `id: Domain[int, range(1, 11)]` allows id values between 1 (inclusive) and 11 (exclusive), or `name: Domain[str, \"John\", \"Jane\", \"Peter\"]` allows only the strings \"John\", \"Jane\", or \"Peter\". 
+* Each field can have a value constraint assigned to it, such that only these values are allowed, e.g.: `id: Domain[int, range(1, 11)]` allows id values between 1 (inclusive) and 11 (exclusive), or `name: Domain[str, \"John\", \"Jane\", \"Peter\"]` allows only the strings \"John\", \"Jane\", or \"Peter\".
 * The `list` type allows for a second type argument specifying the size, e.g.: `list[int, 10]`.
 
 Here is an example that uses these features in combination:
@@ -136,9 +136,18 @@ class CBMCSearchEngineStrategy(EngineStrategy):
         return _SYSTEM_PROMPT.format(self.__output_format)
 
     async def generate_solver_constraints(
-        self, module: Module, metadata: Optional[MetadataWrapper]
-    ) -> str:
-        return LogicPyCHarnessGenerator.generate(module)
+        self, code: str
+    ) -> Optional[SolverConstraints]:
+
+        module: Module
+        module = parse_module(code)
+
+        code = LogicPyCHarnessGenerator.generate(module)
+
+        if not code:
+            return None
+
+        return SolverConstraints(code)
 
     def generate_solver_invocation_command(self, solver_input_file: str) -> list[str]:
         return [
@@ -156,10 +165,10 @@ class CBMCSearchEngineStrategy(EngineStrategy):
         )
 
     def parse_solver_output(
-        self, exit_code: int, stdout: str, stderr: str
+        self, exit_code: int, stdout: SolverConstraints, stderr: str
     ) -> Tuple[SolverOutcome, Optional[str]]:
         if exit_code == 10:
-            cbmc_json_output: Any = loads(stdout)
+            cbmc_json_output: Any = loads(stdout.content)
             parsed_output: str = CBMCSearchEngineStrategy.__parse_cbmc_solution(
                 cbmc_json_output
             )

--- a/agent/logic/cbmc_search_engine_strategy.py
+++ b/agent/logic/cbmc_search_engine_strategy.py
@@ -165,10 +165,10 @@ class CBMCSearchEngineStrategy(EngineStrategy):
         )
 
     def parse_solver_output(
-        self, exit_code: int, stdout: SolverConstraints, stderr: str
+            self, exit_code: int, solverSpec: SolverConstraints, stdout: str, stderr: str
     ) -> Tuple[SolverOutcome, Optional[str]]:
         if exit_code == 10:
-            cbmc_json_output: Any = loads(stdout.content)
+            cbmc_json_output: Any = loads(stdout)
             parsed_output: str = CBMCSearchEngineStrategy.__parse_cbmc_solution(
                 cbmc_json_output
             )

--- a/agent/logic/engine_strategy.py
+++ b/agent/logic/engine_strategy.py
@@ -6,9 +6,8 @@
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Optional, Tuple
-
-from libcst import MetadataWrapper, Module
+from typing import Optional, Tuple, List
+from dataclasses import dataclass
 
 
 class SolverOutcome(Enum):
@@ -30,6 +29,11 @@ class SolverOutcome(Enum):
     # using this response.
     RETRY = 3
 
+@dataclass
+class SolverConstraints:
+    content : str
+    variables: Optional[List[str]] = None
+    nb_categories: Optional[int] = None
 
 class EngineStrategy(ABC):
     """
@@ -62,8 +66,8 @@ class EngineStrategy(ABC):
 
     @abstractmethod
     async def generate_solver_constraints(
-        self, module: Module, metadata: Optional[MetadataWrapper]
-    ) -> str:
+            self, code: str
+    ) -> Optional[SolverConstraints]:
         """
         All supported solvers are invoked using a CLI interface (e.g. `cbmc`,
         `z3`). This method generates constraints for the implemented solver
@@ -71,9 +75,12 @@ class EngineStrategy(ABC):
         solver in a subsequent step.
 
         Args:
-            module (Module): Logic.py Python module to translate.
+            code (str): Logic.py code or puzzle description to translate.
+
         Returns:
-            Solver-specific constraints to later pass into solver engine.
+            Optional[Solverconstraints]:
+            - First element: code ready for the solver.
+            - additional elements: only for Prolog (extracted variables and number of categories).
         """
         ...
 
@@ -107,14 +114,19 @@ class EngineStrategy(ABC):
 
     @abstractmethod
     def parse_solver_output(
-        self, exit_code: int, stdout: str, stderr: str
+        self, exit_code: int, stdout: SolverConstraints , stderr: str
     ) -> Tuple[SolverOutcome, Optional[str]]:
         """
         Interprets the result of the constraint solver subprocess invocation.
 
+        For Prolog, stdout contains additional metadata (extracted variables and number of categories)
+        needed to reconstruct the solution. Other solvers return only the transformed code.
+
         Args:
             exit_code (int): Constraint solver subprocess exit code.
-            stdout (str): Standard output of constraint solver subprocess.
+            stdout (SolverConstraints): Standard output of constraint solver subprocess;
+                first element is always the solver output string. For Prolog, subsequent elements
+                are extracted variables and number of categories.
             stderr (str): Standard error output of constraint solver subprocess.
         Returns:
             A tuple where the first element indicates the outcome (i.e. whether

--- a/agent/logic/engine_strategy.py
+++ b/agent/logic/engine_strategy.py
@@ -114,7 +114,7 @@ class EngineStrategy(ABC):
 
     @abstractmethod
     def parse_solver_output(
-        self, exit_code: int, stdout: SolverConstraints , stderr: str
+            self, exit_code: int, solverSpec: SolverConstraints, stdout: str , stderr: str
     ) -> Tuple[SolverOutcome, Optional[str]]:
         """
         Interprets the result of the constraint solver subprocess invocation.
@@ -124,9 +124,10 @@ class EngineStrategy(ABC):
 
         Args:
             exit_code (int): Constraint solver subprocess exit code.
-            stdout (SolverConstraints): Standard output of constraint solver subprocess;
-                first element is always the solver output string. For Prolog, subsequent elements
-                are extracted variables and number of categories.
+            solverSpec (SolverConstraints): The original solver constraints used as input.
+                This is used by Prolog to access additional metadata 
+                (variables, nb_categories) needed to reconstruct the solution.
+            stdout (str): Standard output of constraint solver subprocess.
             stderr (str): Standard error output of constraint solver subprocess.
         Returns:
             A tuple where the first element indicates the outcome (i.e. whether

--- a/agent/logic/engine_strategy_factory.py
+++ b/agent/logic/engine_strategy_factory.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
 from abc import ABC, abstractmethod
 from agent.logic.prolog_engine_strategy import PrologEngineStrategy
 from agent.logic.cbmc_search_engine_strategy import CBMCSearchEngineStrategy

--- a/agent/logic/engine_strategy_factory.py
+++ b/agent/logic/engine_strategy_factory.py
@@ -1,0 +1,38 @@
+from abc import ABC, abstractmethod
+from agent.logic.prolog_engine_strategy import PrologEngineStrategy
+from agent.logic.cbmc_search_engine_strategy import CBMCSearchEngineStrategy
+from agent.logic.z3_conclusion_check_engine_strategy import Z3ConclusionCheckEngineStrategy
+from agent.logic.engine_strategy import EngineStrategy
+from logging import Logger
+from typing import Callable
+
+class EngineStrategyFactory(ABC):
+    """
+    Abstract factory interface for creating EngineStrategy instances.
+    """
+    @abstractmethod
+    def create(self,logger_factory: Callable[[str], Logger], puzzle: str, output_format: str) -> EngineStrategy:
+        """
+        Creates an instance of an EngineStrategy suitable for solving the given puzzle.
+
+        Args:
+            logger_factory (Callable[[str], Logger]): A callable that produces loggers for the given module name.
+            puzzle (str): A textual representation of the logic puzzle to solve.
+            output_format (str): The expected output format (JSON).
+
+        Returns:
+            EngineStrategy: A concrete instance implementing the logic for solving the specified puzzle.
+        """
+        ...
+
+class PrologStrategyFactory(EngineStrategyFactory):
+    def create(self,logger_factory, puzzle: str, output_format: str) -> EngineStrategy:
+        return PrologEngineStrategy(logger_factory, puzzle, output_format)
+
+class CbmcStrategyFactory(EngineStrategyFactory):
+    def create(self,logger_factory, puzzle: str, output_format: str) -> EngineStrategy:
+        return CBMCSearchEngineStrategy(logger_factory, puzzle, output_format)
+
+class Z3StrategyFactory(EngineStrategyFactory):
+    def create(self,logger_factory, puzzle: str, output_format: str) -> EngineStrategy:
+        return Z3ConclusionCheckEngineStrategy(logger_factory, puzzle, output_format)

--- a/agent/logic/folio_benchmark.py
+++ b/agent/logic/folio_benchmark.py
@@ -145,7 +145,7 @@ class FOLIOBenchmark:
                 logger_factory, self.__model_name
             ) as chat_completion:
                 agent = LogicAgent(
-                    logger_factory, chat_completion, engine_strategy, result_trace, True
+                    logger_factory, chat_completion, engine_strategy, result_trace
                 )
                 await agent.solve()
         traces[task_id] = result_trace

--- a/agent/logic/prolog_engine_strategy.py
+++ b/agent/logic/prolog_engine_strategy.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
 from logging import Logger
 from typing import Any, Callable, Optional, Tuple, List
 import ast
@@ -158,13 +164,18 @@ class PrologEngineStrategy(EngineStrategy):
         )
 
     def parse_solver_output(
-        self, exit_code: int, stdout: SolverConstraints, stderr: str
+            self, exit_code: int, solverSpec: SolverConstraints, stdout: str, stderr: str
     ) -> Tuple[SolverOutcome, Optional[str]]:
-        ret = stdout.content
+        
         if exit_code == 0:
-            ints = ast.literal_eval(ret)
-            vars : list[str] = stdout.variables
-            n : int = stdout.nb_categories
+            if solverSpec.variables is None or solverSpec.nb_categories is None:
+                self.__logger.error(
+                    "SolverConstraints is missing required fields: 'variables' and 'nb_categories' must be set."
+                )   
+                return SolverOutcome.FATAL, None
+            ints = ast.literal_eval(stdout)
+            vars : list[str] = solverSpec.variables
+            n : int = solverSpec.nb_categories
             res = PrologEngineStrategy._parse_prolog_solution(ints, vars, n)
             return SolverOutcome.SUCCESS, res
 

--- a/agent/logic/prolog_engine_strategy.py
+++ b/agent/logic/prolog_engine_strategy.py
@@ -1,0 +1,244 @@
+from logging import Logger
+from typing import Any, Callable, Optional, Tuple, List
+import ast
+from agent.logic.engine_strategy import EngineStrategy, SolverOutcome, SolverConstraints
+import re
+
+
+_CODE_PREFIX: str =""":- use_module(library(clpfd))."""
+# Instructs the model to generate the solution constraints.
+_CONSTRAINTS_MESSAGE: str = r"""
+You have already defined the data structure of a logic puzzle (variable declarations, grouping, and `all_different` constraints). Now, proceed to the **second step**: write the **logical constraints** and the **output display**.
+
+---
+
+Given the following puzzle description (including all clues), generate the following:
+
+### 1. Constraints Section
+- Translate **each clue** into a Prolog constraint syntax.
+- For each constraint, **add a comment above it** with the format:
+  `% Clue X: <original clue in plain English>`
+- Do not skip or merge clues — each clue must have exactly one matching constraint and one comment.
+- Use the same variable names defined in the `Vars` and groups (e.g., `Eric`, `Arnold`, `Dog`, etc.).
+** Your solver tool supports only these 4 operators `#=`, `#<`, `#>`, `#\=` and only the function `abs/1`.
+Here is an exmple to follow:
+    % Clue 1: The person whose child is Fred is somewhere to the left of Eric.
+    Fred #< Eric,
+    % Clue 2: There are two houses between The person whose mother's name is Penny and the person who is short.
+    abs(Penny - Short) #= 3,
+    % Clue 3: The person whose favorite color is red is in the second house.
+    Red #= 2,
+    % Clue 4: The rabbit owner is directly left of The person whose mother's name is Aniya.
+    Rabbit #= Aniya - 1,
+
+- and finally you shoud label and print the results
+labeling([], Vars),
+write(Vars), nl. ** this line needs to end with a point '.'
+
+"""
+
+_DATA_STRUCTURE_MESSAGE: str = """Here is the puzzle:
+```
+{}
+```
+"""
+
+# Instructs the model to format the solver solution according to the requested format
+_FORMAT_MESSAGE: str = """Your logic solver tool produced the following solution:
+```
+{solution}
+```
+
+Now convert it to the expected output format:
+```
+{output_format}
+```
+"""
+
+# Instructs the model on how to generate a solution data structure.
+_SYSTEM_PROMPT: str = """
+You are an expert puzzle solving agent with access to a propositional logic solver tool a prolog alike that has a convenient interface optimised for you. Your boss has given you a logic puzzle that he thinks can be mapped to your logic solver tool
+
+I will walk you through these steps one by one. Do **not** attempt to solve the puzzle or anticipate future steps unless I explicitly ask you to. We will now begin with the **first step**: define the **data structure** for a valid puzzle solution.
+
+---
+
+Given the following puzzle description (including both entity definitions and logical constraints), extract only the structure of the solution space as follows:
+
+### Your task:
+1. create prdicate solve/0 where we are gonna work in
+2. **Extract all entities** from the puzzle (e.g., names, pets, colors, objects...).
+3. Create a **single flat list** named `Vars` that contains all the variables (e.g., `[Eric, Arnold, Dog, Cat]`).**All variable names must begin with an uppercase letter.**
+4. Add the domain constraint:
+   `Vars ins 1..N`,
+   where `N` is the number of houses or positions.
+5. **Group them by logical category** (e.g., Names, Pets, Colors...).
+6. For each group, create a variable group declaration like:
+   `Names = [Eric, Arnold],
+7. For each group, also add a constraint:
+   `all_different(Names),`
+8. End the last line with a coma ',', do not use a point '.'
+9. Do not translate the clues or constraints yet — we will handle that in later steps.
+10. **put your prolog code in between ``` ```
+---
+here is an exemple :
+```
+solve :-
+    % Extract all entities from the puzzle
+    Vars = [Alice, Eric, Arnold, Peter,
+        Google_Pixel_6, Iphone_13, Oneplus_9, Samsung_Galaxy_S21],
+
+    Vars ins 1..4,
+    Names = [Alice, Eric, Arnold, Peter],
+    PhoneModels = [Google_Pixel_6, Iphone_13, Oneplus_9, Samsung_Galaxy_S21],
+
+    % Add constraints for each group
+    all_different(Names),
+    all_different(PhoneModels),
+```
+
+In order to automatically validate the puzzle solution, your data structure will eventually need to be converted to JSON in the following format, so keep that in mind when deciding on your data structure:
+```
+{}
+```
+"""
+
+
+# Sent if the solver was unable to find a solution.
+_UNSAT_MESSAGE: str = (
+    "Your constraints are contradictory and thus the solver could not find a solution. Please review them and try to spot the error, we will go through the step of generating the `def validate(solution: Solution) -> None` function again."
+)
+
+
+
+class PrologEngineStrategy(EngineStrategy):
+    """
+    Solves search-based problems using a Prolog.
+    """
+
+    def __init__(
+        self, logger_factory: Callable[[str], Logger], task: str, output_format: str
+    ) -> None:
+        """
+        Args:
+            logger_factory (Callable[[str], Logger]): Log configuration.
+            task (str): Search-based problem to solve.
+            output_format (str): Output format expected by the user.
+        """
+        self.__logger: Logger = logger_factory(__name__)
+        self.__task: str = task
+        self.__output_format: str = output_format
+
+    @property
+    def constraints_prompt(self) -> list[str]:
+        return [_CONSTRAINTS_MESSAGE]
+
+    @property
+    def data_structure_prompt(self) -> str:
+        return _SYSTEM_PROMPT.format(self.__output_format)
+
+    async def generate_solver_constraints(self, code: str ) -> Optional[SolverConstraints]:
+        variables = PrologEngineStrategy._extract_variables(code)
+        nb_categories = PrologEngineStrategy._extract_num(code)
+        if variables and nb_categories :
+            return SolverConstraints(code,variables, nb_categories)
+        return None
+
+    def generate_solver_invocation_command(self, solver_input_file: str) -> list[str]:
+        return ["swipl",
+                "-s",
+                solver_input_file,
+                "-g",
+                "solve",
+                "-t", "halt"]
+
+    def get_format_prompt(self, solution: str) -> Optional[str]:
+        return _FORMAT_MESSAGE.format(
+            solution=solution, output_format=self.__output_format
+        )
+
+    def parse_solver_output(
+        self, exit_code: int, stdout: SolverConstraints, stderr: str
+    ) -> Tuple[SolverOutcome, Optional[str]]:
+        ret = stdout.content
+        if exit_code == 0:
+            ints = ast.literal_eval(ret)
+            vars : list[str] = stdout.variables
+            n : int = stdout.nb_categories
+            res = PrologEngineStrategy._parse_prolog_solution(ints, vars, n)
+            return SolverOutcome.SUCCESS, res
+
+        self.__logger.error(f"Prolog solver failed: {stderr}")
+        return SolverOutcome.FATAL, None
+
+    @property
+    def python_code_prefix(self) -> str:
+        return _CODE_PREFIX
+
+    @property
+    def retry_prompt(self) -> str:
+        return _UNSAT_MESSAGE
+
+    @property
+    def solver_input_file_suffix(self) -> str:
+        return ".pl"
+
+    @property
+    def system_prompt(self) -> str:
+        return _DATA_STRUCTURE_MESSAGE.format(self.__task)
+
+    @staticmethod
+    def _parse_prolog_solution(ints: List[int], vars: List[str], n: int) -> str:
+        """
+        Converts the Prolog solver output into a human-readable format by house.
+
+        Args:
+            ints (List[int]): List of integers representing the position of each variable within its category.
+            vars (List[str]): List of variable names in the order defined in the puzzle.
+            n (int): Number of houses (or positions).
+
+        Returns:
+            str: A multi-line string where each line corresponds to a house,
+                 listing the variables associated with that house separated by commas.
+
+        """
+        m = len(vars) // n
+        res = [["" for _ in range(m)] for _ in range(n)]
+        for i in range(len(vars)):
+            idx = i // n
+            res[ints[i]-1][idx] = vars[i]
+
+        return "\n".join(f"{i+1} - {', '.join(ligne)}" for i, ligne in enumerate(res))
+
+
+    @staticmethod
+    def _extract_variables(text: str) -> List[str]:
+        """
+        Extracts the list of variable names from a Prolog puzzle code snippet.
+
+        Args:
+            text (str): Prolog code containing a `Vars = [...]` declaration.
+
+        Returns:
+            Optional[List[str]]: A list of variable names if found; otherwise None.
+        """
+        match = re.search(r'Vars\s*=\s*\[(.*?)\]', text, re.DOTALL)
+        if not match:
+            return []
+        return [v.strip() for v in match.group(1).split(',') if v.strip()]
+
+    @staticmethod
+    def _extract_num(text: str) -> int:
+        """
+        Extracts the number of houses (or the upper bound of the domain) from a Prolog puzzle code snippet.
+
+        Args:
+            text (str): Prolog code containing a `Vars ins 1..N` declaration.
+
+        Returns:
+            int: The upper bound N if found; otherwise None.
+        """
+        match = re.search(r"Vars\s+ins\s+1\.\.(\d+)", text, re.DOTALL)
+        if not match:
+            return 0
+        return int(match.group(1))

--- a/agent/logic/tests/test_prolog_engine_strategy.py
+++ b/agent/logic/tests/test_prolog_engine_strategy.py
@@ -1,0 +1,166 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import Mock
+from agent.logic.prolog_engine_strategy import PrologEngineStrategy
+from agent.logic.engine_strategy import SolverOutcome, SolverConstraints
+
+
+class TestPrologEngineStrategy(IsolatedAsyncioTestCase):
+    def __init__(self, methodName="runTest"):
+        super().__init__(methodName)
+        self.maxDiff = None
+        self.logger_factory = lambda name: Mock()
+
+    def test_extract_variables_and_num(self):
+        code = """
+        solve :-
+            Vars = [Alice, Bob, Cat, Dog],
+            Vars ins 1..2,
+            Names = [Alice, Bob],
+            Pets = [Cat, Dog],
+            all_different(Names),
+            all_different(Pets),
+        """
+        variables = PrologEngineStrategy._extract_variables(code)
+        num = PrologEngineStrategy._extract_num(code)
+        self.assertEqual(variables, ["Alice", "Bob", "Cat", "Dog"])
+        self.assertEqual(num, 2)
+
+    def test_parse_prolog_solution(self):
+        ints = [1, 2, 1, 2]
+        vars = ["Alice", "Bob", "Cat", "Dog"]
+        n = 2
+        res = PrologEngineStrategy._parse_prolog_solution(ints, vars, n)
+        expected = "1 - Alice, Cat\n2 - Bob, Dog"
+        self.assertEqual(res, expected)
+
+    def test_parse_solver_output_success(self):
+        strategy = PrologEngineStrategy(self.logger_factory, "puzzle text", "json")
+        stdout = SolverConstraints("[1,2]", ["Alice", "Bob"], 2)
+        exit_code = 0
+        outcome, res = strategy.parse_solver_output(exit_code, stdout, "")
+        self.assertEqual(outcome, SolverOutcome.SUCCESS)
+        self.assertIsNotNone(res, "Result should not be None")
+        assert res is not None
+        self.assertIn("Alice", res)
+        self.assertIn("Bob", res)
+
+    def test_parse_solver_output_failure(self):
+        mock_logger = Mock()
+        strategy = PrologEngineStrategy(lambda _: mock_logger, "puzzle text", "json")
+        stdout = SolverConstraints("", [], 0)
+        exit_code = 1
+        outcome, res = strategy.parse_solver_output(exit_code, stdout, "error")
+        self.assertEqual(outcome, SolverOutcome.FATAL)
+        self.assertIsNone(res)
+        mock_logger.error.assert_called_once()
+
+
+    async def test_6x6(self):
+
+        prolog_code ="""
+    :- use_module(library(clpfd)).
+    solve :-
+        % Extract all entities from the puzzle
+        Vars = [Alice, Carol, Eric, Peter, Bob, Arnold,
+            Classical, HipHop, Jazz, Pop, Rock, Country,
+            Sarah, Penny, Aniya, Janelle, Kailyn, Holly,
+            AliceChild, Fred, Timothy, Bella, Samantha, Meredith,
+            VeryShort, Short, Tall, VeryTall, SuperTall, Average,
+            Bird, Dog, Horse, Rabbit, Cat, Fish],
+
+        Vars ins 1..6,
+        Names = [Alice, Carol, Eric, Peter, Bob, Arnold],
+        MusicGenres = [Classical, HipHop, Jazz, Pop, Rock, Country],
+        Mothers = [Sarah, Penny, Aniya, Janelle, Kailyn, Holly],
+        Children = [AliceChild, Fred, Timothy, Bella, Samantha, Meredith],
+        Heights = [VeryShort, Short, Tall, VeryTall, SuperTall, Average],
+        Animals = [Bird, Dog, Horse, Rabbit, Cat, Fish],
+
+        % Add constraints for each group
+        all_different(Names),
+        all_different(MusicGenres),
+        all_different(Mothers),
+        all_different(Children),
+        all_different(Heights),
+        all_different(Animals),
+
+        % Clue 1: The person who loves pop music is the cat lover.
+        Pop #= Cat,
+        % Clue 2: The rabbit owner is directly left of the person whose mother's name is Aniya.
+        Rabbit #= Aniya - 1,
+        % Clue 3: The person whose mother's name is Holly is directly left of Carol.
+        Holly #= Carol - 1,
+        % Clue 4: The person whose mother's name is Holly has a child named Alice.
+        AliceChild #= Holly,
+        % Clue 5: The person whose mother's name is Holly loves classical music.
+        Classical #= Holly,
+        % Clue 6: The person who loves jazz music has mother named Sarah.
+        Jazz #= Sarah,
+        % Clue 7: The person whose child is Meredith is somewhere to the right of the person whose mother's name is Aniya.
+        Meredith #> Aniya,
+        % Clue 8: The person who is super tall has mother named Holly.
+        SuperTall #= Holly,
+        % Clue 9: The person who is the mother of Timothy is Bob.
+        Timothy #= Bob,
+        % Clue 10: The person who is very short is somewhere to the left of the person whose mother's name is Aniya.
+        VeryShort #< Aniya,
+        % Clue 11: Eric is the fish enthusiast.
+        Eric #= Fish,
+        % Clue 12: The person whose child is Samantha is somewhere to the right of the person who is very tall.
+        Samantha #> VeryTall,
+        % Clue 13: The person who loves rock music has mother named Janelle.
+        Rock #= Janelle,
+        % Clue 14: There is one house between the person who keeps horses and the person whose child is Meredith.
+        abs(Horse - Meredith) #= 2,
+        % Clue 15: The person whose child is Bella is somewhere to the right of Peter.
+        Bella #> Peter,
+        % Clue 16: The fish enthusiast is somewhere to the left of the bird keeper.
+        Fish #< Bird,
+        % Clue 17: The fish enthusiast is somewhere to the right of the person whose child is Alice.
+        Fish #> AliceChild,
+        % Clue 18: There is one house between the person whose child is Bella and the person who loves rock music.
+        abs(Bella - Rock) #= 2,
+        % Clue 19: The person who is short is the cat lover.
+        Short #= Cat,
+        % Clue 20: Alice is directly left of the person who loves classical music.
+        Alice #= Classical - 1,
+        % Clue 21: The person whose child is Bella has mother named Aniya.
+        Bella #= Aniya,
+        % Clue 22: There are two houses between the person whose mother is Penny and the person who is short.
+        abs(Penny - Short) #= 3,
+        % Clue 23: The person who loves hip-hop music is in the first house.
+        HipHop #= 1,
+        % Clue 24: Carol is the person who is tall.
+        Carol #= Tall,
+
+        labeling([], Vars),
+        write(Vars), nl.
+        """
+
+        # Create the strategy instance
+        strategy = PrologEngineStrategy(self.logger_factory, "6x6 puzzle", "json")
+
+        # Generate solver constraints
+        solver_spec = await strategy.generate_solver_constraints(prolog_code)
+        self.assertIsNotNone(solver_spec, "Solver spec should not be None")
+        assert solver_spec is not None
+
+        expected_vars = [1, 3, 5, 2, 4, 6, #Names (Alice -> house 1, Carol -> house 3, Eric -> house 5, ...)
+                         2, 1, 6, 4, 5, 3, #MusicGenres
+                         6, 1, 3, 5, 4, 2, #Mothers
+                         2, 1, 4, 3, 6, 5, #Children
+                         1, 4, 3, 5, 2, 6, #Heights
+                         6, 1, 3, 2, 4, 5  #Animals
+                         ]
+
+        exit_code = 0
+        stdout = SolverConstraints(
+            str(expected_vars),
+            solver_spec.variables,
+            solver_spec.nb_categories
+        )
+        outcome, res = strategy.parse_solver_output(exit_code, stdout, "")
+        self.assertEqual(outcome, SolverOutcome.SUCCESS)
+
+        expected_res = "1 - Alice, HipHop, Penny, Fred, VeryShort, Dog\n2 - Peter, Classical, Holly, AliceChild, SuperTall, Rabbit\n3 - Carol, Country, Aniya, Bella, Tall, Horse\n4 - Bob, Pop, Kailyn, Timothy, Short, Cat\n5 - Eric, Rock, Janelle, Meredith, VeryTall, Fish\n6 - Arnold, Jazz, Sarah, Samantha, Average, Bird"
+        self.assertEqual(res, expected_res)

--- a/agent/logic/tests/test_prolog_engine_strategy.py
+++ b/agent/logic/tests/test_prolog_engine_strategy.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import Mock
 from agent.logic.prolog_engine_strategy import PrologEngineStrategy
@@ -35,9 +41,10 @@ class TestPrologEngineStrategy(IsolatedAsyncioTestCase):
 
     def test_parse_solver_output_success(self):
         strategy = PrologEngineStrategy(self.logger_factory, "puzzle text", "json")
-        stdout = SolverConstraints("[1,2]", ["Alice", "Bob"], 2)
+        solverSpec = SolverConstraints("code", ["Alice", "Bob"], 2)
+        stdout = "[1,2]"
         exit_code = 0
-        outcome, res = strategy.parse_solver_output(exit_code, stdout, "")
+        outcome, res = strategy.parse_solver_output(exit_code,solverSpec, stdout, "")
         self.assertEqual(outcome, SolverOutcome.SUCCESS)
         self.assertIsNotNone(res, "Result should not be None")
         assert res is not None
@@ -47,9 +54,10 @@ class TestPrologEngineStrategy(IsolatedAsyncioTestCase):
     def test_parse_solver_output_failure(self):
         mock_logger = Mock()
         strategy = PrologEngineStrategy(lambda _: mock_logger, "puzzle text", "json")
-        stdout = SolverConstraints("", [], 0)
+        solverSpec = SolverConstraints("code", [], 0)
+        stdout = ""
         exit_code = 1
-        outcome, res = strategy.parse_solver_output(exit_code, stdout, "error")
+        outcome, res = strategy.parse_solver_output(exit_code,solverSpec, stdout, "error")
         self.assertEqual(outcome, SolverOutcome.FATAL)
         self.assertIsNone(res)
         mock_logger.error.assert_called_once()
@@ -154,12 +162,8 @@ class TestPrologEngineStrategy(IsolatedAsyncioTestCase):
                          ]
 
         exit_code = 0
-        stdout = SolverConstraints(
-            str(expected_vars),
-            solver_spec.variables,
-            solver_spec.nb_categories
-        )
-        outcome, res = strategy.parse_solver_output(exit_code, stdout, "")
+        stdout = str(expected_vars)
+        outcome, res = strategy.parse_solver_output(exit_code, solver_spec, stdout, "")
         self.assertEqual(outcome, SolverOutcome.SUCCESS)
 
         expected_res = "1 - Alice, HipHop, Penny, Fred, VeryShort, Dog\n2 - Peter, Classical, Holly, AliceChild, SuperTall, Rabbit\n3 - Carol, Country, Aniya, Bella, Tall, Horse\n4 - Bob, Pop, Kailyn, Timothy, Short, Cat\n5 - Eric, Rock, Janelle, Meredith, VeryTall, Fish\n6 - Arnold, Jazz, Sarah, Samantha, Average, Bird"

--- a/agent/logic/tests/test_zebra_benchmark.py
+++ b/agent/logic/tests/test_zebra_benchmark.py
@@ -11,6 +11,8 @@ from unittest import IsolatedAsyncioTestCase
 import aiofiles
 
 from agent.logic.zebra_benchmark import ZebraBenchmark
+from agent.logic.engine_strategy_factory import EngineStrategyFactory
+from agent.logic.engine_strategy_factory import CbmcStrategyFactory
 
 from dotenv import load_dotenv
 
@@ -165,10 +167,12 @@ class TestZebraBenchmark(IsolatedAsyncioTestCase):
         with NamedTemporaryFile() as eval_json_file:
             eval_json_file.close()
             eval_json_file_name: str = eval_json_file.name
+            solver_factory: EngineStrategyFactory = CbmcStrategyFactory()
             zebraBenchmark = ZebraBenchmark(
                 eval_json_file_name,
                 "meta-llama/Meta-Llama-3.1-70B-Instruct@reasoning",
                 "llama3-70b-instruct",
+                solver_factory,
                 True,
                 False,
                 None,

--- a/agent/logic/z3_conclusion_check_engine_strategy.py
+++ b/agent/logic/z3_conclusion_check_engine_strategy.py
@@ -8,7 +8,7 @@ from logging import Logger
 from types import SimpleNamespace
 from typing import Callable, Optional, Tuple
 
-from agent.logic.engine_strategy import EngineStrategy, SolverOutcome
+from agent.logic.engine_strategy import EngineStrategy, SolverOutcome, SolverConstraints
 
 from agent.logic.logic_py_smt_harness_generator import LogicPySMTHarnessGenerator
 
@@ -259,8 +259,14 @@ class Z3ConclusionCheckEngineStrategy(EngineStrategy):
         )
 
     async def generate_solver_constraints(
-        self, module: Module, metadata: Optional[MetadataWrapper]
-    ) -> str:
+        self, code: str
+    ) -> Optional[SolverConstraints]:
+
+        metadata: Optional[MetadataWrapper]
+        metadata = await ModuleWithTypeInfoFactory.create_module(
+                        code
+        )
+
         if metadata is None:
             raise ValueError("SMT back-end needs type information enabled")
 
@@ -268,7 +274,7 @@ class Z3ConclusionCheckEngineStrategy(EngineStrategy):
         wrapper: MetadataWrapper = await ModuleWithTypeInfoFactory.create_module(
             preprocessed.code
         )
-        return LogicPySMTHarnessGenerator.generate(wrapper)
+        return SolverConstraints(LogicPySMTHarnessGenerator.generate(wrapper))
 
     def generate_solver_invocation_command(self, solver_input_file: str) -> list[str]:
         return ["z3", solver_input_file]
@@ -277,11 +283,11 @@ class Z3ConclusionCheckEngineStrategy(EngineStrategy):
         return None
 
     def parse_solver_output(
-        self, exit_code: int, stdout: str, stderr: str
+        self, exit_code: int, stdout: SolverConstraints, stderr: str
     ) -> Tuple[SolverOutcome, Optional[str]]:
         if exit_code == 0:
             output: str
-            match stdout:
+            match stdout.content:
                 case z3_output_patterns._FALSE:
                     output = "False"
                 case z3_output_patterns._RETRY:

--- a/agent/logic/z3_conclusion_check_engine_strategy.py
+++ b/agent/logic/z3_conclusion_check_engine_strategy.py
@@ -283,11 +283,11 @@ class Z3ConclusionCheckEngineStrategy(EngineStrategy):
         return None
 
     def parse_solver_output(
-        self, exit_code: int, stdout: SolverConstraints, stderr: str
+            self, exit_code: int, solverSpec: SolverConstraints, stdout: str, stderr: str
     ) -> Tuple[SolverOutcome, Optional[str]]:
         if exit_code == 0:
             output: str
-            match stdout.content:
+            match stdout:
                 case z3_output_patterns._FALSE:
                     output = "False"
                 case z3_output_patterns._RETRY:

--- a/agent/logic/zebra_benchmark.py
+++ b/agent/logic/zebra_benchmark.py
@@ -16,7 +16,9 @@ from typing import Any, Callable, Optional, Tuple
 import aiofiles
 
 from agent.logic.agent import LogicAgent
-from agent.logic.cbmc_search_engine_strategy import CBMCSearchEngineStrategy
+from agent.logic.engine_strategy_factory import EngineStrategyFactory
+from agent.logic.engine_strategy_factory import CbmcStrategyFactory
+from agent.logic.engine_strategy_factory import PrologStrategyFactory
 from agent.logic.engine_strategy import EngineStrategy
 from agent.logic.model_only import ModelOnlySolver
 from aiofiles.base import AiofilesContextManager
@@ -52,6 +54,7 @@ class ZebraBenchmark:
         eval_json_file_name: str,
         generator: str,
         model_name: str,
+        solver_factory: EngineStrategyFactory,
         enable_stderr_log: bool = True,
         generate_training_data: bool = False,
         zebra_input_dataset_path: Optional[str] = None,
@@ -63,6 +66,8 @@ class ZebraBenchmark:
             eval_json_file_name (str): Result JSON output file.
             generator (str): Generator name used in ZebraLogic leader board.
             model_name (str): Name of model to use in inference client.
+            solver_factory (EngineStrategyFactory): Factory instance responsible
+            for producing the engine strategy.
             enable_stderr_log (bool): Indicates whether log messages should be
             writting to stderr as well as the result JSON. Disabled for unit
             tests.
@@ -82,6 +87,7 @@ class ZebraBenchmark:
         self.__generator: str = generator
         self.__model_name: str = model_name
         self.__model_only: bool = model_only
+        self.__solver_factory = solver_factory
         self.__enable_stderr_log: bool = enable_stderr_log
         self.__filter_dataset: Callable[[dict[str, Any]], bool] = filter_dataset
         self.__output_dataset_context: Optional[AiofilesContextManager] = (
@@ -154,7 +160,7 @@ class ZebraBenchmark:
         log_stream = StringIO()
         result_trace = ResultTrace(task_id)
         with LoggerFactory(log_stream, self.__enable_stderr_log) as logger_factory:
-            engine_strategy: EngineStrategy = CBMCSearchEngineStrategy(
+            engine_strategy: EngineStrategy = self.__solver_factory.create(
                 logger_factory, puzzle, output_format
             )
             async with create_chat_completion(
@@ -404,11 +410,13 @@ async def main():
             "gpt-4o-evals2",
         ),
     ]
+    solver_factory: EngineStrategyFactory = CbmcStrategyFactory()
     for model in models:
         async with ZebraBenchmark(
             model[0],
             model[1],
             model[2],
+            solver_factory,
         ) as benchmark:
             await benchmark.run()
 


### PR DESCRIPTION
# Refactor Engine Strategies & Add Prolog Engine Strategy

### Added
- `PrologEngineStrategy` for puzzle-solving and `EngineStrategyFactory` for managing engine strategies

### Changes
- Refactored `EngineStrategy` and `LogicAgent` 
- Updated CBMC and Z3 strategies for compatibility
- Tests for Prolog engine in `test_prolog_engine_strategy.py`

### Testing
```bash
python -m unittest agent/logic/tests/test_prolog_engine_strategy.py
python -m unittest agent/logic/tests/test_zebra_benchmark.py